### PR TITLE
Re-working internal machinery for HA

### DIFF
--- a/go-controller/pkg/cluster/cluster.go
+++ b/go-controller/pkg/cluster/cluster.go
@@ -76,3 +76,13 @@ func setupOVNNode(nodeName string) error {
 	}
 	return nil
 }
+
+func setupOVNMaster(nodeName string) error {
+	// Configure both server and client of OVN databases, since master uses both
+	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
+		if err := auth.SetDBAuth(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -1217,31 +1217,15 @@ func (a *OvnAuthConfig) SetDBAuth() error {
 	return nil
 }
 
-func (a *OvnAuthConfig) updateIP(newIP []string, port string) error {
-	if a.Address != "" {
-		s := strings.Split(a.Address, ":")
-		if len(s) != 3 {
-			return fmt.Errorf("failed to parse OvnAuthConfig address %q", a.Address)
-		}
-		var newPort string
-		if port != "" {
-			newPort = port
-		} else {
-			newPort = s[2]
-		}
-
-		newAddresses := make([]string, 0, len(newIP))
-		for _, ipAddress := range newIP {
-			newAddresses = append(newAddresses, s[0]+":"+ipAddress+":"+newPort)
-		}
-		a.Address = strings.Join(newAddresses, ",")
-	}
+func (a *OvnAuthConfig) updateIP(newIP string, port string) error {
+	a.Address = string(OvnDBSchemeTCP) + ":" + newIP + ":" + port
+	a.Scheme = OvnDBSchemeTCP
 	return nil
 }
 
 // UpdateOVNNodeAuth updates the host and URL in ClientAuth
 // for both OvnNorth and OvnSouth. It updates them with the new masterIP.
-func UpdateOVNNodeAuth(masterIP []string, southboundDBPort, northboundDBPort string) error {
+func UpdateOVNNodeAuth(masterIP string, southboundDBPort, northboundDBPort string) error {
 	logrus.Debugf("Update OVN node auth with new master ip: %s", masterIP)
 	if err := OvnNorth.updateIP(masterIP, northboundDBPort); err != nil {
 		return fmt.Errorf("failed to update OvnNorth ClientAuth URL: %v", err)

--- a/go-controller/pkg/factory/factory_test.go
+++ b/go-controller/pkg/factory/factory_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -188,7 +188,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				cache.ResourceEventHandlerFuncs{},
 				func(objs []interface{}) {
 					Expect(len(objs)).To(Equal(1))
-				})
+				}, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(h).NotTo(BeNil())
 			wf.removeHandler(objType, h)
@@ -246,7 +246,7 @@ var _ = Describe("Watch Factory Operations", func() {
 					},
 					UpdateFunc: func(old, new interface{}) {},
 					DeleteFunc: func(obj interface{}) {},
-				}, nil)
+				}, nil, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(numAdded).To(Equal(2))
 			wf.removeHandler(objType, h)
@@ -307,7 +307,7 @@ var _ = Describe("Watch Factory Operations", func() {
 				numDeleted++
 				funcs.DeleteFunc(obj)
 			},
-		}, nil)
+		}, nil, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(h).NotTo(BeNil())
 		return h

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -43,22 +43,20 @@ func (k *Kube) SetAnnotationOnPod(pod *kapi.Pod, key, value string) error {
 	// escape double quotes in the annotation value so it can be sent as a JSON patch
 	value = strings.Replace(value, "\"", "\\\"", -1)
 	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, key, value)
-	_, err := k.KClient.CoreV1().Pods(pod.Namespace).Patch(pod.Name, types.MergePatchType, []byte(patchData))
-	if err != nil {
-		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", pod.Name, pod.Namespace, err)
+	if _, err := k.KClient.CoreV1().Pods(pod.Namespace).Patch(pod.Name, types.MergePatchType, []byte(patchData)); err != nil {
+		return fmt.Errorf("error setting annotation on pod %s/%s: %v", pod.Name, pod.Namespace, err)
 	}
-	return err
+	return nil
 }
 
 // SetAnnotationOnNode takes the node object and key/value string pair to set it as an annotation
 func (k *Kube) SetAnnotationOnNode(node *kapi.Node, key, value string) error {
-	logrus.Infof("Setting annotations %s=%s on node %s", key, value, node.Name)
+	logrus.Infof("setting annotations %s=%s on node %s", key, value, node.Name)
 	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, key, value)
-	_, err := k.KClient.CoreV1().Nodes().Patch(node.Name, types.MergePatchType, []byte(patchData))
-	if err != nil {
-		logrus.Errorf("Error in setting annotation on node %s: %v", node.Name, err)
+	if _, err := k.KClient.CoreV1().Nodes().Patch(node.Name, types.MergePatchType, []byte(patchData)); err != nil {
+		return fmt.Errorf("error setting annotation on node %s: %v", node.Name, err)
 	}
-	return err
+	return nil
 }
 
 // GetAnnotationsOnPod obtains the pod annotations from kubernetes apiserver, given the name and namespace

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -304,7 +304,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		podCIDR, podMac, gatewayIP, annotation)
 	err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
 	if err != nil {
-		logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
+		logrus.Errorf(err.Error())
 	}
 	oc.addPodToNamespaceAddressSet(pod.Namespace, podIP.String())
 

--- a/go-controller/pkg/ovn/policy.go
+++ b/go-controller/pkg/ovn/policy.go
@@ -2,6 +2,8 @@ package ovn
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -9,7 +11,6 @@ import (
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-	"strings"
 )
 
 func (oc *Controller) syncNetworkPoliciesPortGroup(
@@ -484,7 +485,7 @@ func (oc *Controller) handleLocalPodSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oc.handleLocalPodSelectorAddFunc(policy, np, newObj)
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching local pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
@@ -529,7 +530,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 						UpdateFunc: func(oldObj, newObj interface{}) {
 							oc.handlePeerPodSelectorAddUpdate(policy, np, addressMap, addressSet, newObj)
 						},
-					}, nil)
+					}, nil, false)
 				if err != nil {
 					logrus.Errorf("error watching pods in namespace %s for policy %s: %v", namespace.Name, policy.Name, err)
 					return
@@ -548,7 +549,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				return
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching namespaces for policy %s: %v",
 			policy.Name, err)
@@ -630,7 +631,7 @@ func (oc *Controller) handlePeerPodSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oc.handlePeerPodSelectorAddUpdate(policy, np, addressMap, addressSet, newObj)
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching peer pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
@@ -711,7 +712,7 @@ func (oc *Controller) handlePeerNamespaceSelector(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				return
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching namespaces for policy %s: %v",
 			policy.Name, err)

--- a/go-controller/pkg/ovn/policy_old.go
+++ b/go-controller/pkg/ovn/policy_old.go
@@ -2,6 +2,8 @@ package ovn
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/factory"
 	"github.com/ovn-org/ovn-kubernetes/go-controller/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -9,7 +11,6 @@ import (
 	knet "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-	"strings"
 )
 
 func (oc *Controller) syncNetworkPoliciesOld(networkPolicies []interface{}) {
@@ -620,7 +621,7 @@ func (oc *Controller) handleLocalPodSelectorOld(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oc.handleLocalPodSelectorAddFuncOld(policy, np, newObj)
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching local pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
@@ -704,7 +705,7 @@ func (oc *Controller) handlePeerPodSelectorOld(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				oc.handlePeerPodSelectorAddUpdateOld(policy, np, addressMap, addressSet, newObj)
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching peer pods for policy %s in namespace %s: %v",
 			policy.Name, policy.Namespace, err)
@@ -750,7 +751,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelectorOld(
 						UpdateFunc: func(oldObj, newObj interface{}) {
 							oc.handlePeerPodSelectorAddUpdateOld(policy, np, addressMap, addressSet, newObj)
 						},
-					}, nil)
+					}, nil, false)
 				if err != nil {
 					logrus.Errorf("error watching pods in namespace %s for policy %s: %v", namespace.Name, policy.Name, err)
 					return
@@ -769,7 +770,7 @@ func (oc *Controller) handlePeerNamespaceAndPodSelectorOld(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				return
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching namespaces for policy %s: %v",
 			policy.Name, err)
@@ -850,7 +851,7 @@ func (oc *Controller) handlePeerNamespaceSelectorOld(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				return
 			},
-		}, nil)
+		}, nil, false)
 	if err != nil {
 		logrus.Errorf("error watching namespaces for policy %s: %v",
 			policy.Name, err)

--- a/go-controller/pkg/util/util_test.go
+++ b/go-controller/pkg/util/util_test.go
@@ -53,27 +53,6 @@ var _ = Describe("Util tests", func() {
 				expectedResult: true,
 			},
 			{
-				name: "valid endpoint, multiple IPs",
-				subsets: []kapi.EndpointSubset{
-					{
-						Addresses: []kapi.EndpointAddress{
-							{IP: "10.1.2.3"}, {IP: "11.1.2.3"},
-						},
-						Ports: []kapi.EndpointPort{
-							{
-								Name: "north",
-								Port: 1234,
-							},
-							{
-								Name: "south",
-								Port: 4321,
-							},
-						},
-					},
-				},
-				expectedResult: true,
-			},
-			{
 				name: "invalid endpoint two few ports",
 				subsets: []kapi.EndpointSubset{
 					{
@@ -126,7 +105,7 @@ var _ = Describe("Util tests", func() {
 			test := kapi.Endpoints{
 				Subsets: tc.subsets,
 			}
-			Expect(validateOVNConfigEndpoint(&test)).To(Equal(tc.expectedResult), " test case \"%s\" returned %t instead of %t", tc.name, !tc.expectedResult, tc.expectedResult)
+			Expect(isValidOVNConfigEndpoint(&test)).To(Equal(tc.expectedResult), " test case \"%s\" returned %t instead of %t", tc.name, !tc.expectedResult, tc.expectedResult)
 		}
 	})
 
@@ -156,34 +135,7 @@ var _ = Describe("Util tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nbDBPort).To(Equal(int32(1234)), " test case returned %t instead of 1234", nbDBPort)
 		Expect(sbDBPort).To(Equal(int32(4321)), " test case returned %t instead of 4321", sbDBPort)
-		Expect(masterIPList).To(Equal([]string{"10.1.2.3"}), " test case returned %t instead of []string{\"10.1.2.3\"}", masterIPList)
-
-		//valid endpoint, multiple IPs
-		subsets = []kapi.EndpointSubset{
-			{
-				Addresses: []kapi.EndpointAddress{
-					{IP: "10.1.2.3"}, {IP: "11.1.2.3"},
-				},
-				Ports: []kapi.EndpointPort{
-					{
-						Name: "north",
-						Port: 1234,
-					},
-					{
-						Name: "south",
-						Port: 4321,
-					},
-				},
-			},
-		}
-		test = kapi.Endpoints{
-			Subsets: subsets,
-		}
-		masterIPList, sbDBPort, nbDBPort, err = ExtractDbRemotesFromEndpoint(&test)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(nbDBPort).To(Equal(int32(1234)), " test case returned %t instead of 1234", nbDBPort)
-		Expect(sbDBPort).To(Equal(int32(4321)), " test case returned %t instead of 4321", sbDBPort)
-		Expect(masterIPList).To(Equal([]string{"10.1.2.3", "11.1.2.3"}), " test case returned %t instead of []string{\"10.1.2.3\", \"11.1.2.3\"}", masterIPList)
+		Expect(masterIPList).To(Equal("10.1.2.3"), " test case returned %t instead of \"10.1.2.3\"", masterIPList)
 
 		//invalid endpoint two few ports
 		subsets = []kapi.EndpointSubset{


### PR DESCRIPTION
This PR changes some bits from numans work, in that

* it handles the watching of the endpoints a bit differently to not have multiple watchers step on each other feet
* it changes the error handling from what was previously done
* it removes the invalidIPAddress, as it can cause errors during a new leader election
* it adds more golang specific code stylistic changes

I have created the PR like this, as it will allow reviewers a better view of the changes from his branch to mine.

I know this is a big diff from @numansiddique work, please have a look and decide if you think this is too much and might delay any possible integration of the HA work. Most of these changes are not completely necessary, there are a couple of things which I however saw which will lead to issues if the fixes provided here are not inegrated:

* `WatchEndpoints` in `ovn.go` needs to perform a inverse filter on the `OVNConfigNamespace` as to not interfere with the second watcher we have in `ha_master.go`: `WatchOvnDbEndpoints`. 
* We need a synchronization mechanism in `node.go` `StartClusterNode` to signal when the leader election has been performed and the endpoint is ready. Otherwise `PollImmediate` on L98 will fail repedeatly as it might target an non-master endpoint. I used a channel (`readyChan`) to signal the readiness, but something else might do too. 

Besides that there's mostly a clean up of style and logic, but nothing blocking I'd say. 

Please have a look and let me know. 

@dcbw @girishmg @squeed
