### PR TITLE
interconnect: Ensure LSP fields are updated properly.

### DIFF
--- a/go-controller/pkg/ovn/interconnect/interconnect.go
+++ b/go-controller/pkg/ovn/interconnect/interconnect.go
@@ -311,6 +311,9 @@ func (ic *Controller) addNodeLogicalSwitchPort(logicalSwitchName, portName, port
 			Model: &logicalSwitchPort,
 			OnModelUpdates: []interface{}{
 				&logicalSwitchPort.Addresses,
+				&logicalSwitchPort.Type,
+				&logicalSwitchPort.Options,
+				&logicalSwitchPort.Addresses,
 			},
 			DoAfter: func() {
 				logicalSwitch.Ports = []string{logicalSwitchPort.UUID}


### PR DESCRIPTION
Depending on the order of notifications a transit switch port might
first be created as type=remote and then updated to type=router.  Make
sure this update happens properly.  Otherwise traffic won't flow between
the cluster router and the transit switch.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>
