### PR TITLE
interconnect: Add initial multicast support.

### DIFF
--- a/go-controller/pkg/ovn/interconnect/interconnect.go
+++ b/go-controller/pkg/ovn/interconnect/interconnect.go
@@ -239,8 +239,10 @@ func (ic *Controller) createLocalAzNodeResources(ni nodeInfo) error {
 	logicalSwitch := nbdb.LogicalSwitch{
 		Name: types.TransitSwitch,
 		OtherConfig: map[string]string{
-			"interconn-ts":      types.TransitSwitch,
-			"requested-tnl-key": transitSwitchTunnelKey,
+			"interconn-ts":             types.TransitSwitch,
+			"requested-tnl-key":        transitSwitchTunnelKey,
+			"mcast_snoop":              "true",
+			"mcast_flood_unregistered": "true",
 		},
 	}
 
@@ -249,6 +251,9 @@ func (ic *Controller) createLocalAzNodeResources(ni nodeInfo) error {
 		Name:     logicalRouterPortName,
 		MAC:      ni.tsMac.String(),
 		Networks: []string{ni.tsNet},
+		Options: map[string]string{
+			"mcast_flood": "true",
+		},
 	}
 	logicalRouter := nbdb.LogicalRouter{}
 	opModels := []libovsdbops.OperationModel{
@@ -257,6 +262,7 @@ func (ic *Controller) createLocalAzNodeResources(ni nodeInfo) error {
 			OnModelUpdates: []interface{}{
 				&logicalRouterPort.Networks,
 				&logicalRouterPort.MAC,
+				&logicalRouterPort.Options,
 			},
 			DoAfter: func() {
 				logicalRouter.Ports = []string{logicalRouterPort.UUID}

--- a/test/e2e/multicast.go
+++ b/test/e2e/multicast.go
@@ -82,8 +82,8 @@ var _ = ginkgo.Describe("Multicast", func() {
 
 		// Start the multicast source (iperf client is the sender in multicast)
 		ginkgo.By("creating a pod as a multicast source in node " + clientNodeInfo.name)
-		// multicast group (-c 224.3.3.3), UDP (-u), TTL (-T 2), during (-t 3000) seconds, report every (-i 5) seconds
-		iperf := fmt.Sprintf("iperf -c %s -u -T 2 -t 3000 -i 5", mcastGroup)
+		// multicast group (-c 224.3.3.3), UDP (-u), TTL (-T 3), during (-t 3000) seconds, report every (-i 5) seconds
+		iperf := fmt.Sprintf("iperf -c %s -u -T 3 -t 3000 -i 5", mcastGroup)
 		if IsIPv6Cluster(cs) {
 			iperf = iperf + " -V"
 		}


### PR DESCRIPTION
For now, just flood IP multicast traffic on the transit switch.
