### PR TITLE
interconnect: Store each node's GR IP as annotation.

### DIFF
--- a/go-controller/pkg/ovn/master.go
+++ b/go-controller/pkg/ovn/master.go
@@ -637,6 +637,9 @@ func (oc *Controller) syncGatewayLogicalNetwork(node *kapi.Node, l3GatewayConfig
 		}
 	}
 
+	// Store node's GR IPs as annotations to be used by the interconnect
+	// controller.
+	err = oc.addNodeGRIPsAnnotations(node, gwLRPIPs)
 	return err
 }
 
@@ -912,6 +915,29 @@ func (oc *Controller) ensureNodeLogicalNetwork(node *kapi.Node, hostSubnets []*n
 
 	// Add the node to the logical switch cache
 	return oc.lsManager.AddNode(nodeName, logicalSwitch.UUID, hostSubnets)
+}
+
+// FIXME Copied from addNodeAnnotations (with the same issues).
+func (oc *Controller) addNodeGRIPsAnnotations(node *kapi.Node, grIPs []*net.IPNet) error {
+	nodeAnnotations, err := util.CreateNodeGRIPsAnnotation(grIPs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal node %q annotation for GR IPs %s",
+			node.Name, util.JoinIPNets(grIPs, ","))
+	}
+	err = utilwait.PollImmediate(OvnNodeAnnotationRetryInterval, OvnNodeAnnotationRetryTimeout, func() (bool, error) {
+		err = oc.kube.SetAnnotationsOnNode(node.Name, nodeAnnotations)
+		if err != nil {
+			klog.Warningf("Failed to set node annotation, will retry for: %v",
+				OvnNodeAnnotationRetryTimeout)
+		}
+		return err == nil, nil
+	},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set GR IPs annotation on node %s: %v",
+			node.Name, err)
+	}
+	return nil
 }
 
 func (oc *Controller) addNodeAnnotations(node *kapi.Node, hostSubnets []*net.IPNet) error {


### PR DESCRIPTION
This fixes N-S traffic for services when the selected pods are located on nodes in the Global AZ.  For that we need to add host-routes (/32 or /128) resolving GR IPs of all other nodes.