### PR TITLE
kind-dual-stack-conversion.sh: add ovn-ic support

### DIFF
--- a/contrib/kind-dual-stack-conversion.sh
+++ b/contrib/kind-dual-stack-conversion.sh
@@ -32,7 +32,10 @@ convert_cni() {
   printf '%s' "${FIXED_OVNCONFIG}" | kubectl apply -f -
   # restart ovnkube-master
   # FIXME: kubectl rollout restart deployment leaves the old pod hanging 
-  # as workaround we delete the master directly
+  # as workaround we delete the master directly. When deployed with
+  # OVN_INTERCONNECT_ENABLE=true, the db and ncm pods need that too.
+  kubectl -n ovn-kubernetes delete pod -l name=ovnkube-db ||:
+  kubectl -n ovn-kubernetes delete pod -l name=ovnkube-zone-ncm ||:
   kubectl -n ovn-kubernetes delete pod -l name=ovnkube-master
   # restart ovnkube-node
   kubectl -n ovn-kubernetes rollout restart daemonset ovnkube-node
@@ -103,12 +106,18 @@ SECONDARY_SERVICE_SUBNET=${SECONDARY_SERVICE_SUBNET:-"fd00:10:96::/112"}
 SECONDARY_CLUSTER_SUBNET=${SECONDARY_CLUSTER_SUBNET:-"fd00:10:244::/56"}
 
 # NOTE: ovn only
-export KUBECONFIG=${HOME}/ovn.conf
+export KUBECONFIG=${KUBECONFIG:-${HOME}/ovn.conf}
 
 # KIND nodes
 NODES=$(kind get nodes --name ${CLUSTER_NAME})
 CONTROL_PLANE_NODES=$(kind get nodes --name ${CLUSTER_NAME} | grep control)
 WORKER_NODES=$(kind get nodes --name ${CLUSTER_NAME} | grep worker)
+
+# Warm up images into KIND
+for IMG in registry.k8s.io/e2e-test-images/agnhost:2.21 httpd:2.4 ; do \
+  docker pull $IMG
+  kind load docker-image $IMG --name ovn
+done
 
 # Create a deployment with 2 pods
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
When kind is deployed with OVN_INTERCONNECT_ENABLE=true the conversion was failing because endpoints
were lost after restarting kubelet.
This change addresses that by restarting the ovnkube-db daemonset together with ovnkube-network-controller-manager.

Reported-at: https://issues.redhat.com/browse/SDN-3684

